### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ If you run the code yourself, you can define (a) what Wikipedia languages to cov
 ### Project components
 
 The following Java projects belong to YAGO
-  * Javatools:  These classes are Java utilities. They are shared with other projects.
-  * Basics: These classes are used to represent facts, TSV files, etc.
+  * [Javatools](https://github.com/yago-naga/javatools):  These classes are Java utilities. They are shared with other projects.
+  * [Basics](https://github.com/yago-naga/basics3): These classes are used to represent facts, TSV files, etc.
   The files in "data" describe the schema of YAGO.
   * YAGO: This project contains 
     - all main YAGO extractors

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To run YAGO, you need the following:
   
 ### The YAGO configuration file
 
-YAGO is configured with a configuration file. Use this [template](blob/master/configuration/yago.ini) to generate your own copy of that file. It should contain the following lines:
+YAGO is configured with a configuration file. Use this [template](configuration/yago.ini) to generate your own copy of that file. It should contain the following lines:
 
   * `reuse = true|false`: Specifies whether a new run of YAGO should overwrite or re-use the facts that have already been generated in a previous run.
   * `yagoFolder = ...`: Specifies the folder where the YAGO facts shall be stored.


### PR DESCRIPTION
Hi, when trying to access to a link in the README.md (configuration template), it is redirecting to a broken link: https://github.com/yago-naga/yago3/blob/master/blob/master/configuration/yago.ini. This is fixed in the commit. Thanks!

