### PR TITLE
FIX Links in readme and yago.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ YAGO is configured with a configuration file. Use this [template](configuration/
 
 YAGO needs the following data sources: 
   * [Wikipedia](https://www.wikipedia.org/): the [latest version](https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2) of `pages-articles`.
-  * [Wikidata](https://www.wikidata.org): the latest [version](https://dumps.wikimedia.org/wikidatawiki/entities/20170612/wikidata-20170612-all-BETA.ttl.bz2) of `wikidata-DATE-all-ttl`.
+  * [Wikidata](https://www.wikidata.org): the latest [version](https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.ttl.bz2) of `wikidata-DATE-all-ttl`.
   * [Wikimedia Commons](https://commons.wikimedia.org): the [latest version(https://dumps.wikimedia.org/commonswiki/latest/commonswiki-latest-pages-articles.xml.bz2) of pages-articles.
   * [Geonames](http://www.geonames.org/): the files 
     [countryInfo](http://download.geonames.org/export/dump/countryInfo.txt), 

--- a/configuration/yago.ini
+++ b/configuration/yago.ini
@@ -28,6 +28,9 @@ yagoSimulationFolder = FOLDER
 # path to wikidata dump
 #wikidata = /GW/D5data-8/yago/dumps/wikidatawiki/20170522/wikidata-20170522-all-BETA.ttl
 
+# path to geonames folder
+# geonames = /GW/D5data-8/yago/dumps/geonames/
+
 # alternatively, specify folder for dumps and languages
 # and use script to download them
 dumpsFolder = FOLDER


### PR DESCRIPTION
Hello,

I was running the source code recently, and noticed some updates could be made:

- The wikidata link could be updated, I added the link that worked for me, if people want to download the most recent file.

- Also, if people are downloading geonames files, they should point to the folder where the files are, which I added to the yago.ini file.

Thanks.